### PR TITLE
Document webhook env sourcing and curl error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ cp .env.example .env # edit values
 ./scripts/deploy_vps.sh user@host
 ```
 
-After deploy set webhook:
+After deploy set webhook (ensure `.env` is sourced or variables are set inline):
 ```bash
-TELEGRAM_BOT_TOKEN=... PUBLIC_BASE_URL=https://yourdomain WEBHOOK_PATH_SECRET=... TELEGRAM_SECRET_TOKEN=... ./scripts/set_webhook.sh
+TELEGRAM_BOT_TOKEN=... PUBLIC_BASE_URL=https://yourdomain:8443 WEBHOOK_PATH_SECRET=... TELEGRAM_SECRET_TOKEN=... ./scripts/set_webhook.sh
 ```
 
 If using self-signed certs, include `certificate` parameter when calling `setWebhook`.

--- a/scripts/set_webhook.sh
+++ b/scripts/set_webhook.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
-curl -s -X POST "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
+# Ensure required variables are set (source .env or set inline before running).
+curl -fsS -X POST "https://api.telegram.org/bot$TELEGRAM_BOT_TOKEN/setWebhook" \
   -F "url=${PUBLIC_BASE_URL}/telegram/${WEBHOOK_PATH_SECRET}" \
   -F "secret_token=${TELEGRAM_SECRET_TOKEN}"


### PR DESCRIPTION
## Summary
- clarify webhook instructions: source `.env` or set variables inline and include port 8443 in `PUBLIC_BASE_URL`
- ensure `set_webhook.sh` fails loudly by using `curl -fsS`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb1d731128832691209e90c356a2e5