### PR TITLE
Avoid double responses in webhook handler

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -23,5 +23,8 @@ bot.start((ctx) => {
 
 export async function handleUpdate(req: Request, res: Response) {
   await bot.handleUpdate(req.body as any, res);
-  res.status(200).end();
+  if (!res.headersSent) {
+    res.status(200).end();
+  }
 }
+


### PR DESCRIPTION
## Summary
- Ensure webhook handler doesn't send a 200 status if a response was already provided

## Testing
- `npm test`
- Manual run of webhook delivery failed: request to Telegram API failed (ENETUNREACH)


------
https://chatgpt.com/codex/tasks/task_e_68bb1d725a448326a757851c2ae22fa7