### PR TITLE
Use project root for bot build context

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,9 @@
 version: '3.8'
 services:
   bot:
-    build: ./bot
+    build:
+      context: .
+      dockerfile: bot/Dockerfile
     environment:
       - TELEGRAM_BOT_TOKEN=${TELEGRAM_BOT_TOKEN}
       - TELEGRAM_SECRET_TOKEN=${TELEGRAM_SECRET_TOKEN}


### PR DESCRIPTION
## Summary
- build bot service from project root with explicit bot/Dockerfile

## Testing
- `npm test`
- `docker compose build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb1d705bcc8326b935646bd24f9a47